### PR TITLE
Adding mariadb and redis servers using docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  mariadb:
+    image: mariadb:latest
+    build:
+      context: ./mariadb
+      dockerfile: Dockerfile
+    container_name: epinga_maridadb
+    environment:
+      MARIADB_ROOT_PASSWORD: epinga_db_master_password
+      MARIADB_DATABASE: epinga_db
+      MARIADB_USER: epinga_db_user
+      MARIADB_PASSWORD: epinga_db_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mariadb_data:/var/lib/mysql
+
+  redis:
+    image: redis:latest
+    build:
+      context: ./redis
+      dockerfile: Dockerfile
+    container_name: epinga_redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  mariadb_data:
+  redis_data:

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,0 +1,11 @@
+FROM mariadb:latest
+
+ENV MARIADB_ROOT_PASSWORD=my-secret-pw
+ENV MARIADB_DATABASE=mydatabase
+ENV MARIADB_USER=myuser
+ENV MARIADB_PASSWORD=mypassword
+
+COPY ./init-epindadb.sql /docker-entrypoint-initdb.d/
+
+EXPOSE 3306
+CMD ["mysqld"]

--- a/docker/mariadb/init-epindadb.sql
+++ b/docker/mariadb/init-epindadb.sql
@@ -1,0 +1,4 @@
+CREATE TABLE mytable (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -1,0 +1,14 @@
+# Use the official Redis image as a base
+FROM redis:latest
+
+# Copy the custom Redis configuration file
+COPY redis.conf /usr/local/etc/redis/redis.conf
+
+# Copy the initialization script
+COPY init-redis.sh /docker-entrypoint-initdb.d/
+
+# Make the script executable
+RUN chmod +x /docker-entrypoint-initdb.d/init-redis.sh
+
+# Run Redis with the custom configuration
+CMD ["redis-server", "/usr/local/etc/redis/redis.conf"]

--- a/docker/redis/init-redis.sh
+++ b/docker/redis/init-redis.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+redis-cli <<EOF
+# Create a list
+LPUSH mylist "item1"
+LPUSH mylist "item2"
+LPUSH mylist "item3"
+
+# Create a set
+SADD myset "member1"
+SADD myset "member2"
+SADD myset "member3"
+
+# Create a hash
+HSET myhash field1 "value1"
+HSET myhash field2 "value2"
+HSET myhash field3 "value3"
+EOF
+

--- a/docker/redis/redis.conf
+++ b/docker/redis/redis.conf
@@ -1,0 +1,3 @@
+# redis.conf
+bind 0.0.0.0
+protected-mode no


### PR DESCRIPTION
create a initial structure of docker compose to init mariadb and redis servers.